### PR TITLE
Update reCAPTCHA SDK v18.4.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,8 +63,8 @@ dependencies {
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native"
-  implementation "com.google.android.recaptcha:recaptcha:18.0.0"
-    implementation 'com.google.android.gms:play-services-base:18.1.0'
+  implementation "com.google.android.recaptcha:recaptcha:18.4.0"
+  implementation 'com.google.android.gms:play-services-base:18.1.0'
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
As part of our regular internal security research and testing, an issue was discovered in reCAPTCHA Enterprise Mobile for Android SDKs v18.0.0 - v18.3.0. The issue has been resolved and customers must update to v18.4.0 to benefit from the security patches. This issue does not affect older versions of the SDK (v16, v17) nor does it affect iOS SDKs